### PR TITLE
Adding YARDStick One project mentions page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,8 @@ Welcome to YARD Stick One's documentation!
 
    yardstickone
    faq
-
+   yardstickone_project_mentions
+   
 .. toctree::
    :maxdepth: 2
    :caption: Firmware

--- a/docs/source/yardstickone_project_mentions.rst
+++ b/docs/source/yardstickone_project_mentions.rst
@@ -1,0 +1,7 @@
+================================================
+YARD Stick One Community Projects and Mentions
+================================================
+
+Have you done something cool with YARD Stick One or mentioned YARD Stick One in one of your presentations? Let us know and we might post a link here!
+
+* `LRS Restauraunt Pagers <https://github.com/jimilinuxguy/lrs-pager-systems-bruteforce>`__ (Jimi Sanchez)


### PR DESCRIPTION
This commit and PR adds a community project page to the YARDStick One documentation source.